### PR TITLE
include bigquery instantiation

### DIFF
--- a/logpush-to-bigquery/index.js
+++ b/logpush-to-bigquery/index.js
@@ -2,6 +2,7 @@
 
 const { BigQuery } = require('@google-cloud/bigquery')
 const { Storage } = require('@google-cloud/storage')
+const bigquery = new BigQuery()
 const storage = new Storage()
 
 async function gcsbq (file, context) {


### PR DESCRIPTION
Saw this error when trying to deploy master as per the documentation seen here:
https://developers.cloudflare.com/logs/tutorials/analyze-logs-gcp/


```
      gcsbq  534377179747205  2019-04-29 17:21:37.701  ReferenceError: bigquery is not defined
                                                                       at addToTable (/srv/index.js:29:21)
                                                                       at gcsbq (/srv/index.js:36:11)
                                                                       at /worker/worker.js:825:24
                                                                       at <anonymous>
                                                                       at process._tickDomainCallback (internal/process/next_tick.js:229:7)
```

This seems to be all that was missing and everything is working as expected now.