### PR TITLE
upgrade to node 10

### DIFF
--- a/logpush-to-bigquery/deploy.sh
+++ b/logpush-to-bigquery/deploy.sh
@@ -8,7 +8,7 @@ REGION="us-central1"
 FN_NAME="gcsbq"
 
 gcloud functions deploy $FN_NAME \
-  --runtime nodejs8 \
+  --runtime nodejs10 \
   --trigger-resource $BUCKET_NAME \
   --trigger-event google.storage.object.finalize \
   --region=$REGION \


### PR DESCRIPTION
According to [docs](https://cloud.google.com/functions/docs/migrating/nodejs-runtimes) and warning emails 

> The Node.js 8 runtime will be deprecated on 2020-06-05

At moment I'm connecting our cloudflare to gcp, and decided to set node to 10 can confirm that everything working

![image](https://user-images.githubusercontent.com/88868/83535234-729ea400-a4fa-11ea-8c80-c07dd8462d59.png)

