### PR TITLE
Add support for time partitioning and expiry

### DIFF
--- a/logpush-to-bigquery/README.md
+++ b/logpush-to-bigquery/README.md
@@ -20,6 +20,8 @@ SCHEMA="" # optional - The schema based on the logs' source. schema-http.json is
 DATASET="" # optional – BigQuery dataset to write to. Will be created if necessary.
 TABLE="" # optional – BigQuery table to write to. Will be created if necessary.
 FN_NAME="" # optional - the name of your Cloud Function | default: gcsbq
+EXPIRATION_MS="" # optional - records should be expired after this amount of time
+TIME_PARTITIONING_FIELD="" # optional - the name of the field used for time partitioning. defaults to "EdgeStartTimestamp". spectrum users will want to change this to "Timestamp".
 
 # Deploy to GCP
 sh ./deploy.sh

--- a/logpush-to-bigquery/index.js
+++ b/logpush-to-bigquery/index.js
@@ -10,6 +10,8 @@ async function gcsbq (file, context) {
 
   const datasetId = process.env.DATASET
   const tableId = process.env.TABLE
+  const expirationMs = process.env.EXPIRATION_MS
+  const timePartitioningField = process.env.TIME_PARTITIONING_FIELD || 'EdgeStartTimestamp'
 
   console.log(`Starting job for ${file.name}`)
 
@@ -22,6 +24,11 @@ async function gcsbq (file, context) {
     sourceFormat: 'NEWLINE_DELIMITED_JSON',
     schema: {
       fields: schema
+    },
+    timePartitioning: {
+      type: 'DAY',
+      expirationMs: expirationMs,
+      field: timePartitioningField
     },
     ignoreUnknownValues: true
   }


### PR DESCRIPTION
The current behaviour is to load everything into a non-partitioned table. That means that queries will scan the entire table every time.

In order to make queries cheaper, we can use time partitioning.

One nice side-effect of this is that we also get the ability to configure expiration.

Note: I could use some help testing out this patch.