### PR TITLE
corrected data types

### DIFF
--- a/logpush-to-bigquery/schema-http.json
+++ b/logpush-to-bigquery/schema-http.json
@@ -126,7 +126,7 @@
   },
    {
     "name": "EdgeEndTimestamp",
-    "type": "TIMESTAMP",
+    "type": "INTEGER",
     "mode": "NULLABLE"
   },
   {
@@ -186,7 +186,7 @@
   },
   {
     "name": "EdgeStartTimestamp",
-    "type": "TIMESTAMP",
+    "type": "INTEGER",
     "mode": "NULLABLE"
   },
   {

--- a/logpush-to-bigquery/schema-spectrum.json
+++ b/logpush-to-bigquery/schema-spectrum.json
@@ -151,7 +151,7 @@
   },
   {
     "name": "Timestamp",
-    "type": "TIMESTAMP",
+    "type": "INTEGER",
     "MODE": "NULLABLE"
   }
 ]

--- a/logpush-to-bigquery/schema-spectrum.json
+++ b/logpush-to-bigquery/schema-spectrum.json
@@ -71,12 +71,12 @@
   },
   {
     "name": "ConnectTimestamp",
-    "type": "STRING",
+    "type": "INTEGER",
     "MODE": "NULLABLE"
   },
   {
     "name": "DisconnectTimestamp",
-    "type": "STRING",
+    "type": "INTEGER",
     "MODE": "NULLABLE"
   },
   {


### PR DESCRIPTION
The reason for this PR is to correct the data types used in the schemas.

If you don't use the correct data types the following errors occur:

```json
{"reason":"invalidQuery","location":"query","message":"Cannot return an invalid timestamp value of -8505438273863876608 microseconds relative to the Unix epoch. The range of valid timestamp values is [0001-01-1 00:00:00, 9999-12-31 23:59:59.999999]; error in writing field EdgeEndTimestamp"}
````

This PR fixes the incorrect data types