### PR TITLE
Feature/update cronjob name

### DIFF
--- a/logpush-to-bigquery/README.md
+++ b/logpush-to-bigquery/README.md
@@ -26,6 +26,7 @@ TABLE="" # optional – BigQuery table to write to. Will be created if necessary
 FN_NAME="" # optional - the name of your Cloud Function | default: gcsbq
 # optional - the name of the pubsub topic that will be published every minute
 TOPIC_NAME=""
+CRON_JOB_NAME="" # optinal - name of the cron job that is being created.
 # Deploy to GCP
 sh ./deploy.sh
 ```

--- a/logpush-to-bigquery/README.md
+++ b/logpush-to-bigquery/README.md
@@ -26,7 +26,7 @@ TABLE="" # optional – BigQuery table to write to. Will be created if necessary
 FN_NAME="" # optional - the name of your Cloud Function | default: gcsbq
 # optional - the name of the pubsub topic that will be published every minute
 TOPIC_NAME=""
-CRON_JOB_NAME="" # optinal - name of the cron job that is being created.
+CRON_JOB_NAME="" # optional - name of the cron job that is being created.
 # Deploy to GCP
 sh ./deploy.sh
 ```

--- a/logpush-to-bigquery/cloudshell.md
+++ b/logpush-to-bigquery/cloudshell.md
@@ -42,7 +42,7 @@ FN_NAME=""
 # optional - the name of the pubsub topic that will be published every minute
 TOPIC_NAME="every_minute"
 
-# optinal - name of the cron job that is being created.
+# optional - name of the cron job that is being created.
 CRON_JOB_NAME="" 
 
 

--- a/logpush-to-bigquery/cloudshell.md
+++ b/logpush-to-bigquery/cloudshell.md
@@ -42,6 +42,10 @@ FN_NAME=""
 # optional - the name of the pubsub topic that will be published every minute
 TOPIC_NAME="every_minute"
 
+# optinal - name of the cron job that is being created.
+CRON_JOB_NAME="" 
+
+
 ```
 
 ## Deploy to GCP

--- a/logpush-to-bigquery/deploy.sh
+++ b/logpush-to-bigquery/deploy.sh
@@ -11,11 +11,12 @@ REGION="us-central1"
 # You probably don't need to change these values:
 FN_NAME="cf-logs-to-bigquery"
 TOPIC_NAME="every_minute"
+CRON_JOB_NAME="cf_logs_cron"
 
 # Create pubsub topic
 gcloud pubsub topics create $TOPIC_NAME
 # Create cron job
-gcloud scheduler jobs create pubsub cf_logs_cron --schedule="* * * * *" --topic=$TOPIC_NAME --message-body="60 seconds passed"
+gcloud scheduler jobs create pubsub $cf_logs_cron --schedule="* * * * *" --topic=$TOPIC_NAME --message-body="60 seconds passed"
 # Deploy function
 gcloud functions deploy $FN_NAME \
   --runtime nodejs12 \

--- a/logpush-to-bigquery/deploy.sh
+++ b/logpush-to-bigquery/deploy.sh
@@ -16,7 +16,7 @@ CRON_JOB_NAME="cf_logs_cron"
 # Create pubsub topic
 gcloud pubsub topics create $TOPIC_NAME
 # Create cron job
-gcloud scheduler jobs create pubsub $cf_logs_cron --schedule="* * * * *" --topic=$TOPIC_NAME --message-body="60 seconds passed"
+gcloud scheduler jobs create pubsub $CRON_JOB_NAME --schedule="* * * * *" --topic=$TOPIC_NAME --message-body="60 seconds passed"
 # Deploy function
 gcloud functions deploy $FN_NAME \
   --runtime nodejs12 \


### PR DESCRIPTION
Hi!

As I was making use of this project I ran into a case where if I ran the deploy twice it would not always overwrite the previous CRON job and I also did not have enough control over the name of the cron job for subsequent runs.

This can cause confusion as GCP will just spit out:

`ERROR: (gcloud.scheduler.jobs.create.pubsub) ALREADY_EXISTS: Job .../jobs/cf_logs_cron already exists.`

Please take a look at the addition of a new variable!

Looking forward to feedback.
Thanks!